### PR TITLE
Add homepage blog preview section

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,6 +126,18 @@
             </div>
         </section>
 
+        <!-- Latest Blog Posts Section -->
+        <section id="latest-posts" class="home-blog">
+            <h2>Latest Blog Posts</h2>
+            <p class="home-blog-intro">Notes on game development, technical design, and the projects I'm building.</p>
+            <div id="home-blog-list" class="home-blog-list">
+                <div class="home-blog-loading">Loading posts...</div>
+            </div>
+            <div class="home-blog-cta">
+                <a href="blog/" class="btn btn-primary">Read the Blog</a>
+            </div>
+        </section>
+
         <hr class="section-divider">
 
         <!-- Archive Section -->
@@ -203,5 +215,6 @@
     </footer>
 
     <script src="js/nav.js"></script>
+    <script src="js/home-blog.js"></script>
 </body>
 </html>

--- a/js/home-blog.js
+++ b/js/home-blog.js
@@ -1,0 +1,43 @@
+// Home page blog preview loader
+document.addEventListener('DOMContentLoaded', async function() {
+    const blogList = document.getElementById('home-blog-list');
+    if (!blogList) return;
+
+    try {
+        const response = await fetch('posts/index.json');
+        if (!response.ok) throw new Error('Failed to load posts index');
+
+        const posts = await response.json();
+
+        if (posts.length === 0) {
+            blogList.innerHTML = '<p class="home-blog-loading">No posts yet. Check back soon!</p>';
+            return;
+        }
+
+        posts.sort((a, b) => new Date(b.date) - new Date(a.date));
+        const latestPosts = posts.slice(0, 3);
+
+        blogList.innerHTML = latestPosts.map(post => {
+            const date = new Date(post.date).toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric'
+            });
+            const tags = post.tags ? post.tags.map(tag =>
+                `<span class="home-blog-tag">${tag}</span>`
+            ).join('') : '';
+
+            return `
+                <article class="home-blog-card">
+                    <h3><a href="blog/post.html?slug=${post.slug}">${post.title}</a></h3>
+                    <div class="home-blog-meta">${date}</div>
+                    <p>${post.description || ''}</p>
+                    ${tags ? `<div class="home-blog-tags">${tags}</div>` : ''}
+                </article>
+            `;
+        }).join('');
+    } catch (error) {
+        console.error('Error loading blog posts:', error);
+        blogList.innerHTML = '<p class="home-blog-loading">Unable to load posts right now.</p>';
+    }
+});

--- a/style.css
+++ b/style.css
@@ -196,6 +196,81 @@ section h2 {
     color: var(--color-text);
 }
 
+/* Home blog section */
+.home-blog {
+    text-align: center;
+    margin-top: 40px;
+}
+
+.home-blog-intro {
+    max-width: 640px;
+    margin: 0 auto 24px auto;
+    color: var(--color-text-muted);
+}
+
+.home-blog-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 20px;
+    margin-bottom: 24px;
+}
+
+.home-blog-card {
+    background: var(--color-card);
+    border-radius: var(--radius);
+    padding: 20px;
+    text-align: left;
+    box-shadow: var(--shadow-md);
+    transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.home-blog-card:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-lg);
+}
+
+.home-blog-card h3 {
+    margin: 0 0 8px 0;
+    font-size: 1.1rem;
+}
+
+.home-blog-meta {
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+    margin-bottom: 12px;
+}
+
+.home-blog-card p {
+    color: var(--color-text-muted);
+    margin: 0;
+    line-height: 1.6;
+}
+
+.home-blog-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.home-blog-tag {
+    background: var(--color-bg);
+    color: var(--color-text-muted);
+    padding: 4px 10px;
+    border-radius: 4px;
+    font-size: 0.75rem;
+}
+
+.home-blog-loading {
+    color: var(--color-text-muted);
+    padding: 24px;
+}
+
+.home-blog-cta {
+    display: flex;
+    justify-content: center;
+}
+
 /* Projects Container */
 .projects-container {
     display: grid;


### PR DESCRIPTION
### Motivation
- Surface recent blog content on the homepage to drive engagement and provide a quick entry point into the dev blog.

### Description
- Add a new `Latest Blog Posts` section to `index.html` with a loading state and a CTA link to the full blog (`blog/`).
- Create `js/home-blog.js` which fetches `posts/index.json`, sorts entries, and renders the latest three posts (handles empty/error states).
- Add homepage-specific styles in `style.css` for `.home-blog`, `.home-blog-card`, tags, loading state, and CTA to match site design.
- Wire the new script into the page by including `js/home-blog.js` in `index.html`.

### Testing
- Launched a local static server with `python -m http.server 8000` and verified the homepage rendered the blog preview via a Playwright screenshot run which produced `artifacts/home-blog.png` (initial Playwright attempts timed out but the final DOM-content screenshot succeeded).
- Committed changes and confirmed files `index.html`, `style.css`, and `js/home-blog.js` were added and staged successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971d57c21b48322913ef1eade540991)